### PR TITLE
Add Ignore Devices

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -44,6 +44,14 @@
           "title": "Location Name",
           "type": "string"
         }
+      },
+      "IgnoreDevices": {
+        "title": "Devices to Ignore",
+        "type": "array",
+        "items": {
+          "title": "Device Name",
+          "type": "string"
+        }
       }
     }
   },

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -128,6 +128,12 @@ export class IKHomeBridgeHomebridgePlatform implements DynamicPlatformPlugin {
 
       this.axInstance.get(command).then((res) => {
         res.data.items.forEach((device) => {
+          if (this.config.IgnoreDevices && this.config.IgnoreDevices.find(d => d.toLowerCase() === device.label.toLowerCase())) {
+            this.log.info(`Ignoring ${device.label} becasue it is in the Ignore Devices list`);
+            return;
+          }
+
+
           if (!this.locationIDsToIgnore.find(locationID => device.locationId === locationID)) {
             this.log.debug('Pushing ' + device.label);
             devices.push(device);


### PR DESCRIPTION
Version 1.1.1 added support for ignoring locations. (Fixes #2). However, for devices linked via a third-party service (e.g. Switchbot), we cannot move a specific device to another location, This PR adds a feature to ignore devices by name. (This also addresses #6 )