### PR TITLE
fixed missing space in line 143, to improve log readability

### DIFF
--- a/src/services/lightService.ts
+++ b/src/services/lightService.ts
@@ -140,7 +140,7 @@ export class LightService extends BaseService {
 
     return new Promise<CharacteristicValue>((resolve, reject) => {
       if (!this.multiServiceAccessory.isOnline()) {
-        this.log.error(this.accessory.context.device.label + 'is offline');
+        this.log.error(this.accessory.context.device.label + ' is offline');
         return reject(new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE));
       }
       this.getStatus().then((success) => {


### PR DESCRIPTION
I noticed in the logs that certain log lines, printed in red in the log, were missing a space.

[6/13/2023, 11:47:55 AM] [Smartthings Plug (IK)] Old Front Porch Lights is offline
[6/13/2023, 11:47:55 AM] [Smartthings Plug (IK)] Old Front Porch Lightsis offline         
[6/13/2023, 11:47:55 AM] [Smartthings Plug (IK)] Available 1 is offline
[6/13/2023, 11:47:55 AM] [Smartthings Plug (IK)] Available 1is offline

In the web based log, the second lines of each set above had the message printed in red.