### PR TITLE
Support for additional optional AC modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 This is a smartthings plugin for Homebridge.  This requires no access to the legacy smartthings app, and doesn't
 require a lot of work to install.  It will discover devices automatically as well as unregister devices that are removed
 from your smarttthings network.  This is currently under development.
+## New in version 1.5.14
+* Support for air conditioners optional modes (i.e., Sleep, Speed, WindFree, WindFreeSleep)
 ## Fixed in version 1.5.13
 * Handle invalid response to "getLevel" call in lightservice.  There is a Zooz driver that 
 does not return a valid response causing homebridge to fail.

--- a/config.schema.json
+++ b/config.schema.json
@@ -72,6 +72,18 @@
         "required": false,
         "default": false
       },
+      "OptionalModeForAirConditioners": {
+        "title": "Select what optional mode to use as additional switch in air conditioners.",
+        "type": "string",
+        "required": false,
+        "enum": [
+          "Sleep",
+          "Speed",
+          "WindFree",
+          "WindFreeSleep"
+        ],
+        "default": "None"
+      },
       "IgnoreLocations": {
         "title": "Locations to Ignore",
         "type": "array",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-smartthings-ik",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-smartthings-ik",
-      "version": "1.5.13",
+      "version": "1.5.14",
       "funding": [
         {
           "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "SmartThings Plugin",
   "name": "homebridge-smartthings-ik",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "Connects SmartThings devices to Homebridge.  Automatically discovers devices.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR includes the following:
- support optional AC modes [Sleep, Speed, WindFree, WindFreeSleep] (#88, #183)
- add configuration selector to pick desired optional mode from a drop down (see pics)

<img width="759" alt="Screenshot 2023-08-12 at 11 19 11" src="https://github.com/iklein99/homebridge-smartthings/assets/21968739/fb159d25-4abe-4b23-8766-2c6df946a85a">

<img width="759" alt="Screenshot 2023-08-12 at 11 20 06" src="https://github.com/iklein99/homebridge-smartthings/assets/21968739/33d35a61-7a45-48d5-b86d-7a18d15b3986">

The behavior of the switch is supposed to be as follows:
- the switch for the optional mode is always exposed, even if a user selects `None` as value
- optional mode is applied to every air conditioner
- a user can change the optional mode without recreating the device from scratch
