### PR TITLE
Support for optional capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 This is a smartthings plugin for Homebridge.  This requires no access to the legacy smartthings app, and doesn't
 require a lot of work to install.  It will discover devices automatically as well as unregister devices that are removed
 from your smarttthings network.  This is currently under development.
+## New in version 1.5.15
+* Support for optional capaiblities declaration
+* AirConditionerService adds fan oscillation switch and optional mode switch only if supported by device's capabilitites
 ## New in version 1.5.14
 * Support for air conditioners optional modes (i.e., Sleep, Speed, WindFree, WindFreeSleep)
 * Stop logging warning if battery is low

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-smartthings-ik",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-smartthings-ik",
-      "version": "1.5.14",
+      "version": "1.5.15",
       "funding": [
         {
           "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "SmartThings Plugin",
   "name": "homebridge-smartthings-ik",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "Connects SmartThings devices to Homebridge.  Automatically discovers devices.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/multiServiceAccessory.ts
+++ b/src/multiServiceAccessory.ts
@@ -81,9 +81,11 @@ export class MultiServiceAccessory {
         'switch',
         'airConditionerMode',
         'airConditionerFanMode',
-        'fanOscillationMode',
         'thermostatCoolingSetpoint',
         'temperatureMeasurement',
+      ],
+      optionalCapabilities: [
+        'fanOscillationMode',
         'relativeHumidityMeasurement',
         'custom.airConditionerOptionalMode',
       ],
@@ -200,6 +202,7 @@ export class MultiServiceAccessory {
     component: any,
     capabilitiesToCover: string[],
     capabilities: string[],
+    optionalCapabilities: string[],
     serviceConstructor: any,
   ): string[] {
     // this.log.debug(`Testing ${serviceConstructor.name} for capabilities ${capabilitiesToCover}`);
@@ -209,13 +212,15 @@ export class MultiServiceAccessory {
       return capabilitiesToCover;
     }
 
-    this.log.debug(`Creating instance of ${serviceConstructor.name} for capabilities ${capabilities}`);
-    const serviceInstance = new serviceConstructor(this.platform, this.accessory, componentId, capabilities, this, this.name, component);
+    const allCapabilities = capabilities.concat(optionalCapabilities.filter(e => capabilitiesToCover.includes(e)))
+
+    this.log.debug(`Creating instance of ${serviceConstructor.name} for capabilities ${allCapabilities}`);
+    const serviceInstance = new serviceConstructor(this.platform, this.accessory, componentId, allCapabilities, this, this.name, component);
     this.services.push(serviceInstance);
 
-    this.log.debug(`Registered ${serviceConstructor.name} for capabilities ${capabilities}`);
+    this.log.debug(`Registered ${serviceConstructor.name} for capabilities ${allCapabilities}`);
     // remove covered capabilities and return unused
-    return capabilitiesToCover.filter(e => !capabilities.includes(e));
+    return capabilitiesToCover.filter(e => !allCapabilities.includes(e));
   }
 
   public addComponent(componentId: string, capabilities: string[]) {
@@ -239,6 +244,7 @@ export class MultiServiceAccessory {
           component,
           capabilitiesToCover,
           entry.capabilities,
+          entry.optionalCapabilities || [],
           entry.service,
         );
       });
@@ -250,6 +256,7 @@ export class MultiServiceAccessory {
         component,
         capabilitiesToCover,
         [capability],
+        [],
         service,
       );
     });


### PR DESCRIPTION
**Add support for optional capabilities in capabilityMap**
- A service can declare a minimum set of capabilities needed to work and an optional set which can be added without preventing the match of the service.
- If an optional capability is matched, it is removed from the set to be matched as it was a capability required by a service


**Support Air conditioners with minimal capabilities set**
- treat `fanOscillationMode`, `relativeHumidityMeasurement`, `custom.airConditionerOptionalMode` as optional capabilitites
- switches for fan oscillation and optional mode are added by AirConditionerService only when supported by device's optional capabilities