### PR TITLE
Homebridge 2.0 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,15 +27,15 @@
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.46.0",
-        "homebridge": "^1.3.5",
+        "homebridge": "^1.6.0 || ^2.0.0-beta.0",
         "nodemon": "^3.0.0",
         "rimraf": "^5.0.0",
         "ts-node": "^10.3.0",
         "typescript": "^5.0.0"
       },
       "engines": {
-        "homebridge": ">=1.3.5",
-        "node": ">=18.0.0"
+        "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+        "node": "^18.20.4 || ^20.15.1 || ^22 || ^24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/iklein99/homebridge-smartthings/issues"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "homebridge": ">=1.3.5"
+    "node": "^18.20.4 || ^20.15.1 || ^22 || ^24",
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0"
   },
   "main": "dist/index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.46.0",
-    "homebridge": "^1.3.5",
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
     "nodemon": "^3.0.0",
     "rimraf": "^5.0.0",
     "ts-node": "^10.3.0",


### PR DESCRIPTION
Ran the plugin through Cursor, tells me based on Homebridge 2.0 documentation and the actual plugin code here, it's already good. Basically, it says the only thing left to do is update package.json to say so...

No plugin source code was changed. Only package.json (and the lockfile) was updated.

Why no code changes:

When we checked the repo against the Homebridge 2.0 / HAP-NodeJS v1 rules, the existing plugin code was already compatible:

    Service/Characteristic – In platform.ts you already use this.api.hap and assign this.Service and this.Characteristic from it, then pass platform.Service / platform.Characteristic into your services. That’s the pattern required for HAP-NodeJS v1.

    Battery – batteryService.ts already uses platform.Service.Battery (the current HAP name; the old BatteryService was removed).

    Deprecated APIs – The codebase doesn’t use any of the removed APIs (e.g. getServiceByUUIDAndSubType, updateReachability, Characteristic.getValue(), enums from Characteristic.Units/Formats/Perms, etc.).

So the only thing left to do for “ready for Homebridge 2.0” was to declare that in package.json (engines and devDependency). The plugin code itself didn’t need edits.

---

- engines.homebridge: ^1.6.0 || ^2.0.0-beta.0
- engines.node: ^18.20.4 || ^20.15.1 || ^22 || ^24
- devDependencies.homebridge: same range for testing

Plugin code already uses api.hap and compatible patterns; no source changes required. See: https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2.0